### PR TITLE
Require chicken extensions used by slurf

### DIFF
--- a/ostatus.meta
+++ b/ostatus.meta
@@ -3,6 +3,6 @@
  (license "GPL")
  (category web)
  (author "jboy")
- (needs http-client openssl uri-common ssax sxpath irregex medea)
+ (needs http-client openssl uri-common ssax sxpath irregex medea atom html-parser)
  (files "ostatus.meta" "ostatus.scm" "ostatus.setup"))
 


### PR DESCRIPTION
This fixes the following issue:

    Warning: extension `atom' is currently not installed